### PR TITLE
fix: add translations for transaction

### DIFF
--- a/utils-transactions/de.json
+++ b/utils-transactions/de.json
@@ -2,6 +2,7 @@
   "data": {
     "suite-utils-transactions-default-transaction": "Transaktion",
     "suite-utils-transactions-money-transaction-book-by-card": "Gebuchter Raum (Karte)",
+    "suite-utils-transactions-money-transaction-book-by-card-with-name": "Booked {propertyName} (card)",
     "suite-utils-transactions-money-transaction-book-by-cash": "Gebuchter Raum (Bar)",
     "suite-utils-transactions-money-transaction-book-by-cash-with-name": "{name} hat {propertyName} in Bar gebucht",
     "suite-utils-transactions-money-transaction-book-refund-cash": "Stornierte Raumbuchung (Bar)",
@@ -21,6 +22,7 @@
     "suite-utils-transactions-money-transaction-status-unpaid": "Zahlung ausstehend",
     "suite-utils-transactions-point-transaction-book-by-points": "Gebuchter Raum (Credits)",
     "suite-utils-transactions-point-transaction-book-by-points-with-name": "{name} hat {propertyName} mit Credits gebucht",
+    "suite-utils-transactions-point-transaction-book-by-points-with-room-name": "Booked {propertyName} with credits",
     "suite-utils-transactions-point-transaction-book-refund-points": "Stornierte Raumbuchung (Credits)",
     "suite-utils-transactions-point-transaction-charge-by-admin": "Credits wurden vom Admin/Moderator abgerechnet.",
     "suite-utils-transactions-point-transaction-charge-by-admin-with-name": "Credits abgerechnet von {name}",

--- a/utils-transactions/de.json
+++ b/utils-transactions/de.json
@@ -2,7 +2,7 @@
   "data": {
     "suite-utils-transactions-default-transaction": "Transaktion",
     "suite-utils-transactions-money-transaction-book-by-card": "Gebuchter Raum (Karte)",
-    "suite-utils-transactions-money-transaction-book-by-card-with-name": "Booked {propertyName} (card)",
+    "suite-utils-transactions-money-transaction-book-by-card-with-name": "Gebucht {propertyName} (card)",
     "suite-utils-transactions-money-transaction-book-by-cash": "Gebuchter Raum (Bar)",
     "suite-utils-transactions-money-transaction-book-by-cash-with-name": "{name} hat {propertyName} in Bar gebucht",
     "suite-utils-transactions-money-transaction-book-refund-cash": "Stornierte Raumbuchung (Bar)",
@@ -22,7 +22,7 @@
     "suite-utils-transactions-money-transaction-status-unpaid": "Zahlung ausstehend",
     "suite-utils-transactions-point-transaction-book-by-points": "Gebuchter Raum (Credits)",
     "suite-utils-transactions-point-transaction-book-by-points-with-name": "{name} hat {propertyName} mit Credits gebucht",
-    "suite-utils-transactions-point-transaction-book-by-points-with-room-name": "Booked {propertyName} with credits",
+    "suite-utils-transactions-point-transaction-book-by-points-with-room-name": "Gebucht {propertyName} mit Credits",
     "suite-utils-transactions-point-transaction-book-refund-points": "Stornierte Raumbuchung (Credits)",
     "suite-utils-transactions-point-transaction-charge-by-admin": "Credits wurden vom Admin/Moderator abgerechnet.",
     "suite-utils-transactions-point-transaction-charge-by-admin-with-name": "Credits abgerechnet von {name}",

--- a/utils-transactions/en.json
+++ b/utils-transactions/en.json
@@ -2,6 +2,7 @@
   "data": {
     "suite-utils-transactions-default-transaction": "Transaction",
     "suite-utils-transactions-money-transaction-book-by-card": "Booked room (card)",
+    "suite-utils-transactions-money-transaction-book-by-card-with-name": "Booked {propertyName} (card)",
     "suite-utils-transactions-money-transaction-book-by-cash": "Booked room (cash)",
     "suite-utils-transactions-money-transaction-book-by-cash-with-name": "{name} booked {propertyName} with cash",
     "suite-utils-transactions-money-transaction-book-refund-cash": "Cancelled room booking (cash)",
@@ -21,6 +22,7 @@
     "suite-utils-transactions-money-transaction-status-unpaid": "Unpaid",
     "suite-utils-transactions-point-transaction-book-by-points": "Booked room (credits)",
     "suite-utils-transactions-point-transaction-book-by-points-with-name": "{name} booked {propertyName} with credits",
+    "suite-utils-transactions-point-transaction-book-by-points-with-room-name": "Booked {propertyName} with credits",
     "suite-utils-transactions-point-transaction-book-refund-points": "Cancelled room booking (credits)",
     "suite-utils-transactions-point-transaction-charge-by-admin": "Credits charged by admin/moderator",
     "suite-utils-transactions-point-transaction-charge-by-admin-with-name": "Credits charged by {name}",

--- a/utils-transactions/es.json
+++ b/utils-transactions/es.json
@@ -2,6 +2,7 @@
   "data": {
     "suite-utils-transactions-default-transaction": "Transacción",
     "suite-utils-transactions-money-transaction-book-by-card": "Reserva de sala de reuniones (tarjeta)",
+    "suite-utils-transactions-money-transaction-book-by-card-with-name": "Booked {propertyName} (card)",
     "suite-utils-transactions-money-transaction-book-by-cash": "Reserva de sala de reuniones (efectivo)",
     "suite-utils-transactions-money-transaction-book-by-cash-with-name": "{name} reservado {propertyName} con efectivo",
     "suite-utils-transactions-money-transaction-book-refund-cash": "Reserva de sala de reuniones cancelada (efectivo)",
@@ -21,6 +22,7 @@
     "suite-utils-transactions-money-transaction-status-unpaid": "No pagado",
     "suite-utils-transactions-point-transaction-book-by-points": "Reserva de sala de reuniones (créditos)",
     "suite-utils-transactions-point-transaction-book-by-points-with-name": "{name} reservado {propertyName} con créditos",
+    "suite-utils-transactions-point-transaction-book-by-points-with-room-name": "Booked {propertyName} with credits",
     "suite-utils-transactions-point-transaction-book-refund-points": "Reserva de sala de reuniones cancelada (créditos)",
     "suite-utils-transactions-point-transaction-charge-by-admin": "Créditos cargardos por el admin/moderador",
     "suite-utils-transactions-point-transaction-charge-by-admin-with-name": "Créditos cargardos por {name}",

--- a/utils-transactions/es.json
+++ b/utils-transactions/es.json
@@ -2,7 +2,7 @@
   "data": {
     "suite-utils-transactions-default-transaction": "Transacción",
     "suite-utils-transactions-money-transaction-book-by-card": "Reserva de sala de reuniones (tarjeta)",
-    "suite-utils-transactions-money-transaction-book-by-card-with-name": "Booked {propertyName} (card)",
+    "suite-utils-transactions-money-transaction-book-by-card-with-name": "Reservado {propertyName} (card)",
     "suite-utils-transactions-money-transaction-book-by-cash": "Reserva de sala de reuniones (efectivo)",
     "suite-utils-transactions-money-transaction-book-by-cash-with-name": "{name} reservado {propertyName} con efectivo",
     "suite-utils-transactions-money-transaction-book-refund-cash": "Reserva de sala de reuniones cancelada (efectivo)",
@@ -22,7 +22,7 @@
     "suite-utils-transactions-money-transaction-status-unpaid": "No pagado",
     "suite-utils-transactions-point-transaction-book-by-points": "Reserva de sala de reuniones (créditos)",
     "suite-utils-transactions-point-transaction-book-by-points-with-name": "{name} reservado {propertyName} con créditos",
-    "suite-utils-transactions-point-transaction-book-by-points-with-room-name": "Booked {propertyName} with credits",
+    "suite-utils-transactions-point-transaction-book-by-points-with-room-name": "Reservado {propertyName} con créditos",
     "suite-utils-transactions-point-transaction-book-refund-points": "Reserva de sala de reuniones cancelada (créditos)",
     "suite-utils-transactions-point-transaction-charge-by-admin": "Créditos cargardos por el admin/moderador",
     "suite-utils-transactions-point-transaction-charge-by-admin-with-name": "Créditos cargardos por {name}",

--- a/utils-transactions/ko.json
+++ b/utils-transactions/ko.json
@@ -2,6 +2,7 @@
   "data": {
     "suite-utils-transactions-default-transaction": "거래",
     "suite-utils-transactions-money-transaction-book-by-card": "회의실 예약 (카드)",
+    "suite-utils-transactions-money-transaction-book-by-card-with-name": "Booked {propertyName} (card)",
     "suite-utils-transactions-money-transaction-book-by-cash": "회의실 예약 (현금)",
     "suite-utils-transactions-money-transaction-book-by-cash-with-name": "{name} {propertyName} 예약 (현금)",
     "suite-utils-transactions-money-transaction-book-refund-cash": "회의실 예약 취소 (현금)",
@@ -21,6 +22,7 @@
     "suite-utils-transactions-money-transaction-status-unpaid": "결제 예정",
     "suite-utils-transactions-point-transaction-book-by-points": "회의실 예약 (크레딧)",
     "suite-utils-transactions-point-transaction-book-by-points-with-name": "{name} {propertyName} 예약 (크레딧)",
+    "suite-utils-transactions-point-transaction-book-by-points-with-room-name": "Booked {propertyName} with credits",
     "suite-utils-transactions-point-transaction-book-refund-points": "회의실 예약 취소 (크레딧)",
     "suite-utils-transactions-point-transaction-charge-by-admin": "관리자/중간관리자 수동 회수",
     "suite-utils-transactions-point-transaction-charge-by-admin-with-name": "크레딧 수동 회수 ({name})",

--- a/utils-transactions/ko.json
+++ b/utils-transactions/ko.json
@@ -2,7 +2,7 @@
   "data": {
     "suite-utils-transactions-default-transaction": "거래",
     "suite-utils-transactions-money-transaction-book-by-card": "회의실 예약 (카드)",
-    "suite-utils-transactions-money-transaction-book-by-card-with-name": "Booked {propertyName} (card)",
+    "suite-utils-transactions-money-transaction-book-by-card-with-name": "{propertyName} 예약 (카드)",
     "suite-utils-transactions-money-transaction-book-by-cash": "회의실 예약 (현금)",
     "suite-utils-transactions-money-transaction-book-by-cash-with-name": "{name} {propertyName} 예약 (현금)",
     "suite-utils-transactions-money-transaction-book-refund-cash": "회의실 예약 취소 (현금)",
@@ -22,7 +22,7 @@
     "suite-utils-transactions-money-transaction-status-unpaid": "결제 예정",
     "suite-utils-transactions-point-transaction-book-by-points": "회의실 예약 (크레딧)",
     "suite-utils-transactions-point-transaction-book-by-points-with-name": "{name} {propertyName} 예약 (크레딧)",
-    "suite-utils-transactions-point-transaction-book-by-points-with-room-name": "Booked {propertyName} with credits",
+    "suite-utils-transactions-point-transaction-book-by-points-with-room-name": "{propertyName} 예약 (크레딧)",
     "suite-utils-transactions-point-transaction-book-refund-points": "회의실 예약 취소 (크레딧)",
     "suite-utils-transactions-point-transaction-charge-by-admin": "관리자/중간관리자 수동 회수",
     "suite-utils-transactions-point-transaction-charge-by-admin-with-name": "크레딧 수동 회수 ({name})",

--- a/utils-transactions/ru.json
+++ b/utils-transactions/ru.json
@@ -2,6 +2,7 @@
   "data": {
     "suite-utils-transactions-default-transaction": "Транзакция",
     "suite-utils-transactions-money-transaction-book-by-card": "Бронь переговорной (карточка)",
+    "suite-utils-transactions-money-transaction-book-by-card-with-name": "Бронь {propertyName} (карточка)",
     "suite-utils-transactions-money-transaction-book-by-cash": "Бронь переговорной (наличные)",
     "suite-utils-transactions-money-transaction-book-by-cash-with-name": "{name} забронировал(а) комнату {propertyName} за наличные",
     "suite-utils-transactions-money-transaction-book-refund-cash": "Отмена брони переговорной (наличные)",
@@ -21,6 +22,7 @@
     "suite-utils-transactions-money-transaction-status-unpaid": "Неоплачено",
     "suite-utils-transactions-point-transaction-book-by-points": "Бронь переговорной (кредиты)",
     "suite-utils-transactions-point-transaction-book-by-points-with-name": "{name} забронировал(а) комнату {propertyName} за кредиты",
+    "suite-utils-transactions-point-transaction-book-by-points-with-room-name": "Бронь {propertyName} за кредиты",
     "suite-utils-transactions-point-transaction-book-refund-points": "Отмена брони переговорной (кредиты)",
     "suite-utils-transactions-point-transaction-charge-by-admin": "Списано кредиты администратором/модератором",
     "suite-utils-transactions-point-transaction-charge-by-admin-with-name": "Списано кредиты ({name})",

--- a/utils-transactions/uk.json
+++ b/utils-transactions/uk.json
@@ -2,6 +2,7 @@
   "data": {
     "suite-utils-transactions-default-transaction": "Транзакція",
     "suite-utils-transactions-money-transaction-book-by-card": "Резервація кімнати (картка)",
+    "suite-utils-transactions-money-transaction-book-by-card-with-name": "Резервація {propertyName} (картка)",
     "suite-utils-transactions-money-transaction-book-by-cash": "Резервація кімнати (готівка)",
     "suite-utils-transactions-money-transaction-book-by-cash-with-name": "{name} зарезервував(ла) кімнату {propertyName} за готівку",
     "suite-utils-transactions-money-transaction-book-refund-cash": "Скасування резервації кімнати (готівка)",
@@ -21,6 +22,7 @@
     "suite-utils-transactions-money-transaction-status-unpaid": "Неоплачено",
     "suite-utils-transactions-point-transaction-book-by-points": "Резервація кімнати (кредити)",
     "suite-utils-transactions-point-transaction-book-by-points-with-name": "{name} зарезервував(ла) кімнату {propertyName} за кредити",
+    "suite-utils-transactions-point-transaction-book-by-points-with-room-name": "Резервація {propertyName} за кредити",
     "suite-utils-transactions-point-transaction-book-refund-points": "Скасування резервації кімнати (кредити)",
     "suite-utils-transactions-point-transaction-charge-by-admin": "Списано кредити адміністратором/модератором",
     "suite-utils-transactions-point-transaction-charge-by-admin-with-name": "Списано кредити ({name})",


### PR DESCRIPTION
For Trello: https://trello.com/c/B06lC6gk/1172-booking-by-card-transaction-text-is-not-descriptive